### PR TITLE
Add missing set_labelprefix use

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -188,6 +188,7 @@ module.exports = grammar({
         $.set_sentinel,
         $.set_condprefix,
         $.set_condenumprefix,
+        $.set_labelprefix,
         $.set_startlabel,
         $.set_posixcaptures,
         $.set_header,

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/config.schema.json",
+  "grammars": [
+    {
+      "name": "re2c",
+      "camelcase": "re2c",
+      "title": "re2c",
+      "scope": "source.re",
+      "file-types": [
+        "re"
+      ],
+      "injection-regex": "^re2c$",
+      "class-name": "TreeSitterRe2c"
+    }
+  ],
+  "metadata": {
+    "version": "0.1.0",
+    "license": "MIT",
+    "description": "re2c grammar for tree-sitter",
+    "authors": [
+      {
+        "name": "Alexandre Muller"
+      }
+    ],
+    "links": {
+      "repository": "https://github.com/tree-sitter-grammars/tree-sitter-re2c"
+    }
+  },
+  "bindings": {
+    "c": true,
+    "go": true,
+    "node": true,
+    "python": true,
+    "rust": true,
+    "swift": true,
+    "zig": false
+  }
+}


### PR DESCRIPTION
Without that $.set_labelprefix is never used and as a result,
labelprefix node is never created in node-types.json, which leads to
test failure.

Add tree-sitter.json.